### PR TITLE
Devel/rdkit normalized descriptors

### DIFF
--- a/chemprop/features/rdkit_normalized_features.py
+++ b/chemprop/features/rdkit_normalized_features.py
@@ -1,0 +1,10 @@
+import numpy as np
+from descriptastorus.descriptors import rdNormalizedDescriptors
+from rdkit import Chem
+
+generator = rdNormalizedDescriptors.RDKit2DNormalized()
+
+def rdkit_2d_normalized_features(smiles: str):
+    # the first element is true/false if the mol was properly computed
+    return generator.process(smiles)[1:]
+

--- a/chemprop/features/rdkit_normalized_features.py
+++ b/chemprop/features/rdkit_normalized_features.py
@@ -1,10 +1,26 @@
 import numpy as np
-from descriptastorus.descriptors import rdNormalizedDescriptors
+import logging
 from rdkit import Chem
 
-generator = rdNormalizedDescriptors.RDKit2DNormalized()
+try:
+    from descriptastorus.descriptors import rdNormalizedDescriptors
+    generator = rdNormalizedDescriptors.RDKit2DNormalized()
+    def rdkit_2d_normalized_features(smiles: str):
+        # the first element is true/false if the mol was properly computed
+        if type(smiles) == str:
+            return generator.process(smiles)[1:]
+        
+        else:
+            # this is a bit of a waste, but the desciptastorus API is smiles
+            #  based for normalization purposes
+            return generator.process(Chem.MolToSmiles(smiles, isomericSmiles=True))[1:]
 
-def rdkit_2d_normalized_features(smiles: str):
-    # the first element is true/false if the mol was properly computed
-    return generator.process(smiles)[1:]
+
+except ImportError:
+    logging.getLogger(__name__).warning("descriptastorus is not available, normalized descriptors are not available")
+    rdkit_2d_normalized_features = None
+
+
+
+
 

--- a/chemprop/features/utils.py
+++ b/chemprop/features/utils.py
@@ -3,6 +3,7 @@ from functools import partial
 import os
 import pickle
 from typing import Callable, List, Union
+import logging
 
 import numpy as np
 from rdkit import Chem
@@ -10,7 +11,7 @@ from rdkit import Chem
 from .descriptors import mordred_features
 from .morgan_fingerprint import morgan_fingerprint
 from .rdkit_features import rdkit_2d_features
-
+from .rdkit_normalized_features import rdkit_2d_normalized_features
 
 def load_features(path: str) -> List[np.ndarray]:
     """
@@ -55,6 +56,13 @@ def get_features_func(features_generator: str,
         assert args is not None
         assert hasattr(args, 'functional_group_smarts')  # TODO: handle this in a better way
         return partial(rdkit_2d_features, args=args)
+
+    if features_generator == "rdkit_2d_normalized":
+       if rdkit_2d_normalized_features is None:
+           logging.getLogger(__name__).warning("Please install descriptastorus for normalized descriptors")
+           raise ValueError('feature_generator type "{}" not installed'.format(features_generator))
+       
+       return rdkit_2d_normalized_features
 
     if features_generator == 'mordred':
         return mordred_features

--- a/chemprop/parsing.py
+++ b/chemprop/parsing.py
@@ -44,7 +44,7 @@ def add_train_args(parser: ArgumentParser):
                         help='Path to .vocab file if using jtnn')
     parser.add_argument('--features_only', action='store_true', default=False,
                         help='Use only the additional features in an FFN, no graph network')
-    parser.add_argument('--features_generator', type=str, nargs='*', choices=['morgan', 'morgan_count', 'rdkit_2d', 'mordred'],
+    parser.add_argument('--features_generator', type=str, nargs='*', choices=['morgan', 'morgan_count', 'rdkit_2d', 'rdkit_2d_normalized', 'mordred'],
                         help='Method of generating additional features')  # TODO allow multiple options
     parser.add_argument('--features_path', type=str,
                         help='Path to features to use in FNN (instead of features_generator)')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn
 scipy
 tensorboardX
 tqdm
+


### PR DESCRIPTION
Adds normalized rdkit descriptors to chem prop

These descriptors are normalized outside of the train/test set on 100K samples from CHEMBL.

n.b. this should be used with --no_features_scaling 